### PR TITLE
Convert PrintF statements with logging calls

### DIFF
--- a/server/agent_connection.go
+++ b/server/agent_connection.go
@@ -34,8 +34,8 @@ import (
 	"encoding"
 	"encoding/binary"
 	"errors"
-	"net"
 	"fmt"
+	"net"
 )
 
 type agentConnection struct {
@@ -102,17 +102,35 @@ func (ac agentConnection) send(o encoding.BinaryMarshaler) error {
 	// write type
 	switch o.(type) {
 	case Hello:
-		ac.Conn.Write([]byte{uint8(TypeHello)})
+		_, err := ac.Conn.Write([]byte{uint8(TypeHello)})
+		if err != nil {
+			log.Errorf("Error occured writing Hello: %s", err.Error())
+		}
 	case Handshake:
-		ac.Conn.Write([]byte{uint8(TypeHandshake)})
+		_, err := ac.Conn.Write([]byte{uint8(TypeHandshake)})
+		if err != nil {
+			log.Errorf("Error occured writing TypeHandshake: %s", err.Error())
+		}
 	case HandshakeResponse:
-		ac.Conn.Write([]byte{uint8(TypeHandshakeResponse)})
+		_, err := ac.Conn.Write([]byte{uint8(TypeHandshakeResponse)})
+		if err != nil {
+			log.Errorf("Error occured writing TypeHandshakeResponse: %s", err.Error())
+		}
 	case ReadWrite:
-		ac.Conn.Write([]byte{uint8(TypeReadWrite)})
+		_, err := ac.Conn.Write([]byte{uint8(TypeReadWrite)})
+		if err != nil {
+			log.Errorf("Error occured writing TypeReadWrite: %s", err.Error())
+		}
 	case Ping:
-		ac.Conn.Write([]byte{uint8(TypePing)})
+		_, err := ac.Conn.Write([]byte{uint8(TypePing)})
+		if err != nil {
+			log.Errorf("Error occured writing TypePing: %s", err.Error())
+		}
 	case EOF:
-		ac.Conn.Write([]byte{uint8(TypeEOF)})
+		_, err := ac.Conn.Write([]byte{uint8(TypeEOF)})
+		if err != nil {
+			log.Errorf("Error occured writing TypeEOF: %s", err.Error())
+		}
 	}
 
 	data, err := o.MarshalBinary()

--- a/server/agent_connection.go
+++ b/server/agent_connection.go
@@ -34,7 +34,6 @@ import (
 	"encoding"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"net"
 )
 
@@ -142,12 +141,12 @@ func (ac agentConnection) send(o encoding.BinaryMarshaler) error {
 	binary.LittleEndian.PutUint16(buff[0:2], uint16(len(data)))
 
 	if _, err := ac.Conn.Write(buff); err != nil {
-		fmt.Printf("Error occured: %s \n", err.Error())
+		log.Errorf("Error occured writing data length: %s \n", err.Error())
 		return err
 	}
 
 	if _, err := ac.Conn.Write(data); err != nil {
-		fmt.Printf("Error occured: %s \n", err.Error())
+		log.Errorf("Error occured writing data: %s \n", err.Error())
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -36,6 +36,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"time"
 
 	"github.com/fatih/color"
@@ -45,6 +46,9 @@ import (
 )
 
 var log = logging.MustGetLogger("agent")
+var format = logging.MustStringFormatter(
+	`%{color}%{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
+)
 
 type Config struct {
 }
@@ -149,6 +153,12 @@ func localIP() string {
 func (a *Agent) Run(ctx context.Context) {
 	fmt.Println(color.YellowString("Honeytrap Agent starting (%s)...", a.token))
 	fmt.Println(color.YellowString("Version: %s (%s)", Version, ShortCommitID))
+
+	backend := logging.NewLogBackend(os.Stdout, "", 0)
+	backendFormatter := logging.NewBackendFormatter(backend, format)
+	backendLeveled := logging.AddModuleLevel(backend)
+	backendLeveled.SetLevel(logging.DEBUG, "")
+	logging.SetBackend(backendLeveled, backendFormatter)
 
 	defer fmt.Println("Honeytrap Agent stopped.")
 

--- a/server/server.go
+++ b/server/server.go
@@ -35,7 +35,6 @@ import (
 	"encoding"
 	"io"
 	"net"
-	"os"
 	"time"
 
 	"github.com/mimoo/disco/libdisco"
@@ -44,9 +43,6 @@ import (
 )
 
 var log = logging.MustGetLogger("agent")
-var format = logging.MustStringFormatter(
-	`%{color}%{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
-)
 
 type Config struct {
 }
@@ -151,10 +147,6 @@ func localIP() string {
 func (a *Agent) Run(ctx context.Context) {
 	log.Infof("Honeytrap Agent starting (%s)...", a.token)
 	log.Infof("Version: %s (%s)", Version, ShortCommitID)
-
-	backend := logging.NewLogBackend(os.Stdout, "", 0)
-	backendFormatter := logging.NewBackendFormatter(backend, format)
-	logging.SetBackend(backend, backendFormatter)
 
 	defer log.Infof("Honeytrap Agent stopped.")
 

--- a/server/server.go
+++ b/server/server.go
@@ -154,9 +154,7 @@ func (a *Agent) Run(ctx context.Context) {
 
 	backend := logging.NewLogBackend(os.Stdout, "", 0)
 	backendFormatter := logging.NewBackendFormatter(backend, format)
-	backendLeveled := logging.AddModuleLevel(backend)
-	backendLeveled.SetLevel(logging.DEBUG, "")
-	logging.SetBackend(backendLeveled, backendFormatter)
+	logging.SetBackend(backend, backendFormatter)
 
 	defer log.Infof("Honeytrap Agent stopped.")
 

--- a/server/server.go
+++ b/server/server.go
@@ -33,13 +33,11 @@ package server
 import (
 	"context"
 	"encoding"
-	"fmt"
 	"io"
 	"net"
 	"os"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/mimoo/disco/libdisco"
 
 	logging "github.com/op/go-logging"
@@ -120,7 +118,7 @@ func (a *Agent) serv(l net.Listener) error {
 			break
 		}
 
-		fmt.Println(color.YellowString("Accepting connection from %s => %s", rw.RemoteAddr().String(), rw.LocalAddr().String()))
+		log.Infof("Accepting connection from %s => %s", rw.RemoteAddr().String(), rw.LocalAddr().String())
 
 		c, err := a.newConn(rw)
 		if err != nil {
@@ -151,8 +149,8 @@ func localIP() string {
 }
 
 func (a *Agent) Run(ctx context.Context) {
-	fmt.Println(color.YellowString("Honeytrap Agent starting (%s)...", a.token))
-	fmt.Println(color.YellowString("Version: %s (%s)", Version, ShortCommitID))
+	log.Infof("Honeytrap Agent starting (%s)...", a.token)
+	log.Infof("Version: %s (%s)", Version, ShortCommitID)
 
 	backend := logging.NewLogBackend(os.Stdout, "", 0)
 	backendFormatter := logging.NewBackendFormatter(backend, format)
@@ -160,14 +158,14 @@ func (a *Agent) Run(ctx context.Context) {
 	backendLeveled.SetLevel(logging.DEBUG, "")
 	logging.SetBackend(backendLeveled, backendFormatter)
 
-	defer fmt.Println("Honeytrap Agent stopped.")
+	defer log.Infof("Honeytrap Agent stopped.")
 
 	go func() {
 		for {
 			a.in = make(chan encoding.BinaryMarshaler)
 
 			func() {
-				fmt.Println(color.YellowString("Connecting to Honeytrap... "))
+				log.Infof("Connecting to Honeytrap... ")
 
 				// configure the Disco connection
 				clientConfig := libdisco.Config{
@@ -185,10 +183,10 @@ func (a *Agent) Run(ctx context.Context) {
 
 				defer cc.Close()
 
-				fmt.Println(color.YellowString("Connected to Honeytrap."))
+				log.Infof("Connected to Honeytrap")
 
 				defer func() {
-					fmt.Println(color.YellowString("Honeytrap disconnected."))
+					log.Infof("Honeytrap disconnected.")
 				}()
 
 				cc.send(Handshake{})
@@ -217,7 +215,7 @@ func (a *Agent) Run(ctx context.Context) {
 					if _, ok := address.(*net.TCPAddr); ok {
 						l, err := net.Listen(address.Network(), address.String())
 						if err != nil {
-							fmt.Println(color.RedString("Error starting listener: %s", err.Error()))
+							log.Errorf("Error starting listener: %s", err.Error())
 							continue
 						}
 
@@ -257,7 +255,7 @@ func (a *Agent) Run(ctx context.Context) {
 						rwcancel()
 						return
 					} else if err != nil {
-						fmt.Println(err.Error())
+						log.Errorf(err.Error())
 						return
 					}
 
@@ -275,7 +273,7 @@ func (a *Agent) Run(ctx context.Context) {
 							break
 						}
 
-						fmt.Println(color.YellowString("Connection closed: %s => %s", v.Raddr.String(), v.Laddr.String()))
+						log.Infof("Connection closed: %s => %s", v.Raddr.String(), v.Laddr.String())
 
 						conn.Close()
 					}


### PR DESCRIPTION
Currently the Agent contains a mix of stdout Printf calls and logging calls.

This PR converts all Printf calls to logging calls for consistency. It also adds more logging for errors when writing to the AgentConnection. 

This can be expanded to a config-based backend like Honeytrap later on. 